### PR TITLE
Allow pointing to different API

### DIFF
--- a/R/cBioPortal.R
+++ b/R/cBioPortal.R
@@ -100,15 +100,24 @@ utils::globalVariables(c("clinicalAttributeId", "value", "sampleId"))
 #' getGenePanel(api = cbio, genePanelId = "IMPACT341")
 #'
 #' @export
-cBioPortal <- function() {
+cBioPortal <- function(apiHostUrl) {
+    if (missing(apiHostUrl)) {
+        apiHost <- "www.cbioportal.org"
+        apiUrl <- "https://www.cbioportal.org/api/api-docs"
+    } else {
+        library(stringr)
+        apiHost <- str_split(apiHostUrl,"//")[[1]][2]
+        apiUrl <- paste(apiHostUrl,"/api/docs", sep="")
+    }
+        
     .cBioPortal(
         Service(
             service = "cBioPortal",
-            host = "www.cbioportal.org",
+            host = apiHost,
             config = httr::config(ssl_verifypeer = 0L, ssl_verifyhost = 0L,
                 http_version = 0L),
             authenticate = FALSE,
-            api_url = "https://www.cbioportal.org/api/api-docs",
+            api_url = apiUrl,
             package = "cBioPortalData",
             schemes = "http"
         )


### PR DESCRIPTION
Need to handle a few more cases:

- [ ] using different port than 80 (e.g. 8080)
- [ ] check if http works as well
- [ ] missing protocol (http / https)

Another question:

- [ ] for caching should that be cleared when switching to use a different API host?