### PR TITLE
Use download.cbioportal.org mirror

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cBioPortalData
 Title: Exposes and makes available data from the cBioPortal web resources
-Version: 2.1.17
+Version: 2.1.18
 Authors@R: c(person("Levi", "Waldron", email = "lwaldron.research@gmail.com",
     role = "aut"),
     person("Marcel", "Ramos", email = "marcel.ramos@roswellpark.org",

--- a/R/cBioDataPack.R
+++ b/R/cBioDataPack.R
@@ -18,6 +18,16 @@
 #' file. For a more fine-grained approach to downloading data from the
 #' cBioPortal API, refer to the `cBioPortalData` function.
 #'
+#' @section cBio_URL:
+#' The `cBioDataPack` function accesses data from the `cBio_URL` option.
+#' By default, it points to an Amazon S3 bucket location. Previously, it
+#' pointed to 'http://download.cbioportal.org'. This recent change
+#' (> 2.1.17) should provide faster and more reliable downloads for all users.
+#' See the URL using `cBioPortalData:::.url_location`. This can be changed
+#' if there are mirrors that host this data by setting the `cBio_URL` option
+#' with `getOption("cBio_URL", "https://some.url.com/")` before running the
+#' function.
+#'
 #' @inheritParams downloadStudy
 #'
 #' @param split.field A character vector of possible column names for the column

--- a/R/downloadStudy.R
+++ b/R/downloadStudy.R
@@ -69,6 +69,9 @@
     .manageLocalFile(cancer_study_id, tmpFile)
 }
 
+# previously http://download.cbioportal.org
+.url_location <- "https://cbioportal-datahub.s3.amazonaws.com"
+
 #' Download and cache study dataset
 #'
 #' Provide a `cancer_study_id` from the `studiesTable` and retrieve
@@ -84,14 +87,18 @@
 #' @param force logical (default FALSE) whether to force re-download data from
 #' remote location
 #'
+#' @param url_location (default "https://cbioportal-datahub.s3.amazonaws.com")
+#' the URL location for downloading packaged data. Can be set using the
+#' 'cBio_URL' option
+#'
 #' @return The file location of the data tarball
 #'
 #' @keywords internal
-downloadStudy <- function(cancer_study_id, use_cache = TRUE, force = FALSE)
+downloadStudy <- function(cancer_study_id, use_cache = TRUE, force = FALSE,
+    url_location = getOption("cBio_URL", .url_location))
 {
     .validStudyID(cancer_study_id)
 
-    url_location <- "http://download.cbioportal.org"
     url_file <- file.path(url_location, paste0(cancer_study_id, ".tar.gz"))
 
     if (is.character(use_cache) && length(use_cache) == 1L)

--- a/data-raw/studiesTable.R
+++ b/data-raw/studiesTable.R
@@ -22,7 +22,7 @@ studiesTable[["description"]] <- gsub("<.*?>", "", studiesTable[["description"]]
 studiesTable <- as(studiesTable, "DataFrame")
 studiesTable[["URL"]] <- URL
 
-fileURLs <- file.path("http://download.cbioportal.org",
+fileURLs <- file.path("https://cbioportal-datahub.s3.amazonaws.com",
     paste0(studiesTable[["cancer_study_id"]], ".tar.gz"))
 ## Requires internet connection
 validURLs <- vapply(fileURLs, RCurl::url.exists, logical(1L))

--- a/inst/docker/Dockerfile
+++ b/inst/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM continuumio/miniconda3
 WORKDIR /app
 
 # Create the environment:
-COPY environment.yml .
+COPY inst/docker/environment.yml .
 RUN conda env update -n base --file environment.yml
 
 # Make RUN commands use the new environment:
@@ -14,9 +14,8 @@ COPY NAMESPACE /app
 COPY R /app/R
 COPY data /app/data
 COPY data-raw /app/data-raw
-COPY inst /app/inst
+COPY inst/docker/scripts /app/scripts
 COPY man /app/man
-COPY scripts /app/scripts
 COPY tests /app/tests
 COPY vignettes /app/vignettes
 

--- a/man/cBioDataPack.Rd
+++ b/man/cBioDataPack.Rd
@@ -48,6 +48,18 @@ particular datasets should open GitHub issues at the URL in the \code{DESCRIPTIO
 file. For a more fine-grained approach to downloading data from the
 cBioPortal API, refer to the \code{cBioPortalData} function.
 }
+\section{cBio_URL}{
+
+The \code{cBioDataPack} function accesses data from the \code{cBio_URL} option.
+By default, it points to an Amazon S3 bucket location. Previously, it
+pointed to 'http://download.cbioportal.org'. This recent change
+(> 2.1.17) should provide faster and more reliable downloads for all users.
+See the URL using \code{cBioPortalData:::.url_location}. This can be changed
+if there are mirrors that host this data by setting the \code{cBio_URL} option
+with \code{getOption("cBio_URL", "https://some.url.com/")} before running the
+function.
+}
+
 \examples{
 
 data(studiesTable)

--- a/man/downloadStudy.Rd
+++ b/man/downloadStudy.Rd
@@ -4,7 +4,12 @@
 \alias{downloadStudy}
 \title{Download and cache study dataset}
 \usage{
-downloadStudy(cancer_study_id, use_cache = TRUE, force = FALSE)
+downloadStudy(
+  cancer_study_id,
+  use_cache = TRUE,
+  force = FALSE,
+  url_location = getOption("cBio_URL", .url_location)
+)
 }
 \arguments{
 \item{cancer_study_id}{The cBioPortal study identifier as in
@@ -16,6 +21,10 @@ not be re-downloaded. A path can also be provided to data cache location.}
 
 \item{force}{logical (default FALSE) whether to force re-download data from
 remote location}
+
+\item{url_location}{(default "https://cbioportal-datahub.s3.amazonaws.com")
+the URL location for downloading packaged data. Can be set using the
+'cBio_URL' option}
 }
 \value{
 The file location of the data tarball


### PR DESCRIPTION
This uses AWS S3 and is a lot faster. But would be nicer if the url was e.g. download.mirror.cbioportal.org but it wasn't that straightforward to set up with SSL. Might update later