### PR TITLE
Fix cBioDataPack error on non-char Patient ID

### DIFF
--- a/R/cBioDataPack.R
+++ b/R/cBioDataPack.R
@@ -200,7 +200,7 @@ cbioportal2metadata <- function(meta_file, lic_file) {
 .subBCLetters <- function(df, ptID = "PATIENT_ID") {
     idVector <- df[[ptID]]
     allBC <- all(grepl("[A-Z]{4}.[0-9]{2}.[0-9]{4}", idVector))
-    noTCGAstart <- !all(startsWith(idVector, "TCGA"))
+    noTCGAstart <- is.character(idVector) && !all(startsWith(idVector, "TCGA"))
     if (allBC && noTCGAstart) {
         idVector <- gsub("^[A-Z]{4}", "TCGA", idVector)
         df[[ptID]] <- idVector

--- a/tests/testthat/test-cBioDataPack.R
+++ b/tests/testthat/test-cBioDataPack.R
@@ -1,0 +1,14 @@
+test_that("Check TGCA patient ID prefix removal works on non-char IDs", {
+  df <- data.frame(PATIENT_ID=c(1,2,3,4))
+  expect_equal(
+    cBioPortalData:::.subBCLetters(df), df
+  )
+})
+
+test_that("Check TGCA patient ID prefix removal works on character IDs", {
+  df <- data.frame(PATIENT_ID=c('ABCDx00x0001', 'EFGHx00x0002'))
+  expected <- data.frame(PATIENT_ID=c('TCGAx00x0001', 'TCGAx00x0002'))
+  expect_equal(
+    cBioPortalData:::.subBCLetters(df), expected
+  )
+})


### PR DESCRIPTION
`cBioDataPack()` smartly checks patient IDs for the prefix "TCGA" to remove it if
needed. That checks errors when the patient ID is not numeric.

Not all studies' patient IDs are characters. For example, `coadread_genentech`'s patient IDs are numeric. Modifying the test
to first check if the IDs are character solves the problem.

Fixes #25.