### PR TITLE
Update cBioPortal.R

### DIFF
--- a/R/cBioPortal.R
+++ b/R/cBioPortal.R
@@ -145,7 +145,7 @@ cBioPortal <- function(
     hostname = "www.cbioportal.org",
     protocol = "https",
     api. = "/api/api-docs",
-    token = character()
+    token = NA_character_
 ) {
     if (length(token))
         token <- c(Authorization = paste("Bearer", token))


### PR DESCRIPTION
Hi 
here i thing avoiding a character() function in the code is better for clarity 
Note that character("a12b3") results in an error Error in character("a12b3") : vector size cannot be NA/NaN
token = put_your_token_here is also clear

i was using cBioPortalData 2.7.2
and the argument token=character("my_token") produced the error above 

nice work