### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,12 @@ Package: cBioPortalData
 Title: Exposes and Makes Available Data from the cBioPortal Web Resources
 Version: 2.23.5
 Authors@R: c(
-    person("Levi", "Waldron", , "lwaldron.research@gmail.com", "aut"),
-    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu",
-      c("aut", "cre"), c(ORCID = "0000-0002-3242-0582")
-    ),
-    person("Karim", "Mezhoud", , "kmezhoud@gmail.com", "ctb")
+    person("Levi", "Waldron", , "lwaldron.research@gmail.com", role = "aut"),
+    person("Marcel", "Ramos", , "marcel.ramos@sph.cuny.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-3242-0582")),
+    person("Karim", "Mezhoud", , "kmezhoud@gmail.com", role = "ctb"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
   )
 Description: The cBioPortalData R package accesses study datasets from the
     cBio Cancer Genomics Portal. It accesses the data either from


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616351583](https://github.com/waldronlab/repo-audits/actions/runs/23616351583)).